### PR TITLE
force => true e unique => true atualizam o permalink do mesmo objeto

### DIFF
--- a/lib/permalink/orm/base.rb
+++ b/lib/permalink/orm/base.rb
@@ -43,13 +43,22 @@ module Permalink
           if self.class.permalink_options[:unique]
             suffix = 2
 
-            while self.class.where(to_permalink_name => the_permalink).first
+            while find_same_permalink(the_permalink)
               the_permalink = "#{_permalink}-#{suffix}"
               suffix += 1
             end
           end
 
           the_permalink
+        end
+
+        def find_same_permalink(_permalink)
+          repeated_permalink = self.class.where(to_permalink_name => _permalink).first
+          repeated_permalink if same_object_with_changes? repeated_permalink
+        end
+
+        def same_object_with_changes?(object)
+          self != object || from_permalink_value != object.send(from_permalink_name)
         end
 
         def from_permalink_name

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Schema.define(:version => 0) do
   create_table :posts do |t|
-    t.string :title, :permalink, :slug
+    t.string :title, :description, :permalink, :slug
   end
 end

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -92,4 +92,24 @@ shared_examples_for "orm" do
 
     record.permalink.should == "awesome-post"
   end
+
+  it "should force permalink and keep unique" do
+    model.permalink :title, :force => true, :unique => true
+
+    record = model.create(:title => "Some nice post")
+    record.update_attributes :title => "Awesome post"
+    record.permalink.should == "awesome-post"
+
+    record = model.create(:title => "Awesome post")
+    record.permalink.should == "awesome-post-2"
+  end
+
+  it "should keep same permalink when another field changes" do
+    model.permalink :title, :force => true, :unique => true
+
+    record = model.create(:title => "Some nice post")
+    record.update_attributes :description => "some description"
+
+    record.permalink.should == "some-nice-post"
+  end
 end


### PR DESCRIPTION
Notei que quando uso options :force => true, :unique => true, o permalink do próprio objeto é modificado mesmo quando eu não altero o from_column_name.

Ex:
permalink :title, :force => true, :unique => true

Post.first
# <Post id: 18, title: "Some nice post", description: nil, permalink: "some-nice-post">

Post.first.update_attribute :description, "some description"
# <Post id: 18, title: "Some nice post", description: "some description", permalink: "some-nice-post-2">

Post.first.update_attribute :description, nil
# <Post id: 18, title: "Some nice post", description: nil, permalink: "some-nice-post">

Adicionei uma condição na consulta se existe outro objeto com o mesmo permalink.
Caso seja ele mesmo, só retorna se o from_column_name tiver mudado.

Faz sentido pra você?
